### PR TITLE
Add start method to use the same node in Graph

### DIFF
--- a/gb_world_model/include/gb_world_model/WorldModelNode.hpp
+++ b/gb_world_model/include/gb_world_model/WorldModelNode.hpp
@@ -26,6 +26,7 @@ class WorldModelNode : public rclcpp::Node
 {
 public:
 	explicit WorldModelNode();
+  void start();
 
 protected:
   std::shared_ptr<ros2_knowledge_graph::GraphNode> graph_;

--- a/gb_world_model/src/gb_world_model/WorldModelNode.cpp
+++ b/gb_world_model/src/gb_world_model/WorldModelNode.cpp
@@ -25,10 +25,15 @@ namespace gb_world_model
 WorldModelNode::WorldModelNode()
 : Node("world_model")
 {
-  graph_ =std::make_shared<ros2_knowledge_graph::GraphNode>(
-    rclcpp::Node::make_shared("world_model_graph"));
-
   declare_parameter("world_root");
+}
+
+void
+WorldModelNode::start()
+{
+  graph_ =std::make_shared<ros2_knowledge_graph::GraphNode>(
+    shared_from_this());
+
   init_graph_node(get_parameter("world_root").as_string());
 }
 
@@ -37,6 +42,7 @@ WorldModelNode::init_graph_node(
   const std::string & node_name,
   const std::string & parent)
 {
+  std::cerr << "init_graph_node" << std::endl;
   declare_parameter(node_name);
   declare_parameter(node_name + ".class");
   declare_parameter(node_name + ".position");

--- a/gb_world_model/src/world_model_main.cpp
+++ b/gb_world_model/src/world_model_main.cpp
@@ -25,6 +25,7 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
 
   auto wm_node = std::make_shared<gb_world_model::WorldModelNode>();
+  wm_node->start();
 
   rclcpp::spin(wm_node);
 


### PR DESCRIPTION
Hi,

The Graph needs a `rclcpp::Node::SharedPtr` added to any executor or spin. We can't do that in the constructor because obtaining a shared_ptr in the constructor is undefined. This PR is a workaround.

Best

Signed-off-by: Francisco Martín Rico <fmrico@gmail.com>